### PR TITLE
Simplify mail validation enough for 3 char tld

### DIFF
--- a/cgi-bin/mail.pm
+++ b/cgi-bin/mail.pm
@@ -54,7 +54,7 @@ sub CheckAddr {
     (my $addr) = @_;
     chomp $addr;
 
-    return ($addr =~ m/^[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?:[A-Z]{2}|edu|com|org|net|gov|mil|biz|int|cat|asia|coop|info|mobi|name|pro|tel|travel|aero|jobs|museum|xxx)$/i);
+    return ($addr =~ m/^[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?:[A-Z]{2}|[A-Z]{3}|asia|coop|info|mobi|name|travel|aero|jobs|museum)$/i);
 }
 
 sub TrimAddr {


### PR DESCRIPTION
This change makes mail validation works on tld 3 characters long.