### PR TITLE
Https support

### DIFF
--- a/ajax.js
+++ b/ajax.js
@@ -20,7 +20,7 @@ function read_from_url(url, cont, err, mimetype) {
             }
         }
     }
-    if (!url.match(/^http:/)) {
+    if (!url.match(/^https?:/)) {
         var prefix = location.href;
         url = prefix.replace(/\/[^\/]*$/, '/') + url;
     }
@@ -47,7 +47,7 @@ function post_to_url(url, params, cont, err, mimetype) {
             }
         }
     }
-    if (!url.match(/^http:/)) {
+    if (!url.match(/^https?:/)) {
         var prefix = location.href;
         url = prefix.replace(/\/[^\/]*$/, '/') + url;
     }

--- a/cgi-bin/civs_common.pm
+++ b/cgi-bin/civs_common.pm
@@ -142,7 +142,7 @@ sub HTML_Header {
 	      start_html(-title => $title,
 	                 -lang => $tx->lang,
 			 -head => Link({ -rel => "shortcut icon",
-			                 -href => "http://www.cs.cornell.edu/w8/~andru/civs/images/check123b.png" }),
+			                 -href => "@PROTO@://www.cs.cornell.edu/w8/~andru/civs/images/check123b.png" }),
 			 -encoding => 'utf-8',
 			 -style => {'src' => "@CIVSURL@/$style"});
       } else {
@@ -152,11 +152,11 @@ sub HTML_Header {
                          -encoding => 'utf-8',
                          -style => {'src' => "@CIVSURL@/$style"},
                          -head => Link({ -rel => "shortcut icon",
-                                         -href => "http://www.cs.cornell.edu/w8/~andru/civs/images/check123b.png" }),
+                                         -href => "@PROTO@://www.cs.cornell.edu/w8/~andru/civs/images/check123b.png" }),
                          -script => [{'src' => "@CIVSURL@/$js"},
                                      {'src' => "@CIVSURL@/ezdom.js"},
-                                     {'src' => "http://ajax.googleapis.com/ajax/libs/jquery/1.4.1/jquery.min.js"},
-                                     {'src' => "http://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/jquery-ui.min.js"}], 
+                                     {'src' => "@PROTO@://ajax.googleapis.com/ajax/libs/jquery/1.4.1/jquery.min.js"},
+                                     {'src' => "@PROTO@://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/jquery-ui.min.js"}], 
                          -onLoad => "setup()");
       }
     }

--- a/cgi-bin/close
+++ b/cgi-bin/close
@@ -34,7 +34,7 @@ if (!sysopen(STOPPED, $stopped_file, O_CREAT|O_EXCL|O_RDWR)) {
     print h1($tx->Poll_ended($title));
     print p($tx->The_poll_has_been_ended($election_end));
     if ($restrict_results ne 'yes') {
-	print p("<a href=\"http://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id\">
+	print p("<a href=\"@PROTO@://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id\">
 	".$tx->View_poll_results.'</a>');
     } else {
 	print p($tx->poll_results_available_to_authorized_users);

--- a/cgi-bin/control
+++ b/cgi-bin/control
@@ -89,7 +89,7 @@ if (!IsStarted) {
     if ($external_ballots eq 'yes') {
 	print p($tx->this_is_a_test_poll), $cr;
     } elsif (defined($public) && $public eq 'yes') {
-	    my $url = "http://$thishost$civs_bin_path/vote@PERLEXT@?id=$election_id";
+	    my $url = "@PROTO@://$thishost$civs_bin_path/vote@PERLEXT@?id=$election_id";
 	    $url .= "&akey=$authorization_key" 
 		    if defined($authorization_key) && $authorization_key ne '';
 	    print p($tx->This_is_a_public_poll_plus_link($url, $publicize eq 'yes')), $cr;
@@ -115,8 +115,8 @@ if (!IsStarted) {
 		($ballot_reporting eq 'yes' && 
 		$reveal_voters eq 'yes' &&
 		$public));
-	    print '<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.1/jquery.min.js"></script>', $cr;
-	    print '<script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/jquery-ui.min.js"></script>', $cr;
+	    print '<script src="@PROTO@://ajax.googleapis.com/ajax/libs/jquery/1.4.1/jquery.min.js"></script>', $cr;
+	    print '<script src="@PROTO@://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/jquery-ui.min.js"></script>', $cr;
 	    print '<script src="@CIVSURL@/vote.js"></script>', $cr;
 	    print '<script>setup()</script>', $cr;
 	    print '</textarea><br>';

--- a/cgi-bin/create_election
+++ b/cgi-bin/create_election
@@ -210,10 +210,10 @@ if ($publicize eq 'yes') {
 }
 $edata{'hash_result_key'} = civs_hash($result_key);
 
-my $url = "http://$thishost$civs_bin_path/control@PERLEXT@?id=$election_id&key=$control_key&akey=$authorization_key";
+my $url = "@PROTO@://$thishost$civs_bin_path/control@PERLEXT@?id=$election_id&key=$control_key&akey=$authorization_key";
 
 if ($publicize eq 'yes') {
-    $url = "http://$thishost$civs_bin_path/control@PERLEXT@?id=$election_id&key=$control_key";
+    $url = "@PROTO@://$thishost$civs_bin_path/control@PERLEXT@?id=$election_id&key=$control_key";
 }
 
 if (!($local_debug)) {
@@ -231,9 +231,9 @@ Send "";
 Send $tx->creation_email_info1($title,$url);
 if ($public eq 'yes') {
     if ($publicize eq 'yes') {
-	Send $tx->creation_email_public_link("http://$thishost$civs_bin_path/vote@PERLEXT@?id=$election_id");
+	Send $tx->creation_email_public_link("@PROTO@://$thishost$civs_bin_path/vote@PERLEXT@?id=$election_id");
     } else {
-	Send $tx->creation_email_public_link("http://$thishost$civs_bin_path/vote@PERLEXT@?id=$election_id&akey=$authorization_key");
+	Send $tx->creation_email_public_link("@PROTO@://$thishost$civs_bin_path/vote@PERLEXT@?id=$election_id&akey=$authorization_key");
     }
 }
 Send $tx->for_more_information_about_CIVS($civs_home);
@@ -277,7 +277,7 @@ sub SendResultKey {
 	}
 	print $tx->Sending_result_key($addr);
 
-	my $url = "http://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id&rkey=$result_key";
+	my $url = "@PROTO@://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id&rkey=$result_key";
 	my $civs_supervisor = '@SUPERVISOR@';
 	Send "mail from:<$civs_supervisor>"; ConsumeSMTP;
 	Send "rcpt to:<$addr>"; ConsumeSMTP;

--- a/cgi-bin/election.pm
+++ b/cgi-bin/election.pm
@@ -239,8 +239,8 @@ sub PointToResults {
 		print '<p>', $tx->following_URL_reports_results, br, $cr;
 
 	}
-	print "<a href=\"http://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id\">
-	<tt>http://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id</tt></a></p>\n";
+	print "<a href=\"@PROTO@://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id\">
+	<tt>@PROTO@://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id</tt></a></p>\n";
     } else {
 	print p($tx->Poll_results_will_be_available_to_the_following_users);
 	print '<ul>';
@@ -274,8 +274,8 @@ sub PointToResultsComplete {
     &ReportResultReaders;
   } else {
     print "<p>", $tx->The_results_of_this_completed_poll_are_here, br, $cr;
-    print "<a href=\"http://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id\">
-       <tt>http://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id</tt></a></p>\n";
+    print "<a href=\"@PROTO@://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id\">
+       <tt>@PROTO@://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id</tt></a></p>\n";
   }
 }
 
@@ -541,7 +541,7 @@ sub SendKeys {
 
         my $url = "";
         if ($public eq 'yes') {
-            $url = "http://$thishost$civs_bin_path/vote@PERLEXT@?id=$election_id";
+            $url = "@PROTO@://$thishost$civs_bin_path/vote@PERLEXT@?id=$election_id";
             $url .= "&akey=$authorization_key"
                 if (&ElectionUsesAuthorizationKey);
         } else {
@@ -554,7 +554,7 @@ sub SendKeys {
                 $voter_keys{$hash_voter_key} = 1;
                 $num_auth++; $edata{'num_auth'} = $num_auth;
             }
-            $url = "http://$thishost$civs_bin_path/vote@PERLEXT@?id=$election_id"
+            $url = "@PROTO@://$thishost$civs_bin_path/vote@PERLEXT@?id=$election_id"
                         ."&key=$voter_key";
         }
 
@@ -617,7 +617,7 @@ sub SendKeys {
 	    $html .= $cr."</p><p>".$tx->poll_has_been_announced_to_end($election_end);
             if ($restrict_results ne 'yes') {
 		$html .= ' ' .
-		  $tx->To_view_the_results_at_the_end(MakeURL("http://$thishost$civs_bin_path/".
+		  $tx->To_view_the_results_at_the_end(MakeURL("@PROTO@://$thishost$civs_bin_path/".
 				"results@PERLEXT@?id=$election_id"));
 	    }
 	    $html .= '<p>' . $tx->For_more_information . $cr .

--- a/cgi-bin/get_top_polls
+++ b/cgi-bin/get_top_polls
@@ -4,9 +4,9 @@ use strict;
 use warnings;
 use CGI qw(:standard);
 use POSIX qw(strftime);
-use languages;
 
 use lib '@CGIBINDIR@';
+use languages;
 
 my $home = '@CIVSDATADIR@';
 

--- a/cgi-bin/get_top_polls
+++ b/cgi-bin/get_top_polls
@@ -29,7 +29,7 @@ open (IN, $top_polls);
 print <IN>;
 
 
-if (@LOG_HOME_VISITS@) {
+if ('@LOG_HOME_VISITS@') {
     my $languages = http('Accept-Language');
     if (!defined($languages)) { $languages = 'unspecified-lang' }
 

--- a/cgi-bin/results
+++ b/cgi-bin/results
@@ -424,7 +424,7 @@ sub BallotReport {
 	    print RESULTS table({-class=>'ballots'},
 		    Tr(\@rows));
 	    print RESULTS p($tx->Ballots_are_shown_in_random_order);
-	    print RESULTS p($tx->Download_ballots_as_a_CSV("http://$thishost$civs_bin_path/download_ballots@PERLEXT@?id=$election_id"));
+	    print RESULTS p($tx->Download_ballots_as_a_CSV("@PROTO@://$thishost$civs_bin_path/download_ballots@PERLEXT@?id=$election_id"));
         } else {
 	    print RESULTS p($tx->No_ballots_were_cast);
 	}

--- a/cgi-bin/top_polls.pm
+++ b/cgi-bin/top_polls.pm
@@ -97,7 +97,7 @@ sub find_top_polls {
     foreach my $id (@eids) {
 	if ($elections{$id} < $min_usage || $count >= $max_full) { last; }
 	my @line = ('<li>',
-			'<a href="http://@THISHOST@@CIVSBINURL@',
+			'<a href="@PROTO@://@THISHOST@@CIVSBINURL@',
 			    '/vote@PERLEXT@?id=' , $id , '">' , escapeHTML($titles{$id}),
 			'</a>',
 		    '</li>', "\r\n");

--- a/cgi-bin/vote
+++ b/cgi-bin/vote
@@ -55,7 +55,7 @@ sub TrySomePolls {
     print p($tx->try_some_public_polls);
     print '<script type="text/javascript" src="@CIVSURL@/ajax.js"></script>';
     print div({id=>"top_polls", class=>"small_list"}, "Loading...");
-    print '<script type="text/javascript">fetch_content("top_polls", "http://@THISHOST@@CIVSBINURL@/get_top_polls@PERLEXT@")</script>';
+    print '<script type="text/javascript">fetch_content("top_polls", "@PROTO@://@THISHOST@@CIVSBINURL@/get_top_polls@PERLEXT@")</script>';
 }
 
 
@@ -145,7 +145,7 @@ print '</div>', $cr;
 
 if ($voting_enabled && $public eq 'yes') {
     print div({class => 'normal_text'}, 
-	p($tx->if_you_have_already_voted("http://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id")));
+	p($tx->if_you_have_already_voted("@PROTO@://$thishost$civs_bin_path/results@PERLEXT@?id=$election_id")));
 }
 
 &CIVS_End;

--- a/cgi-bin/voting.pm
+++ b/cgi-bin/voting.pm
@@ -18,7 +18,7 @@ sub GenerateVoteForm {
     }
 
     print '<form method="post"
-      action="http://@THISHOST@'.$civs_bin_path.'/vote@PERLEXT@"
+      action="@PROTO@://@THISHOST@'.$civs_bin_path.'/vote@PERLEXT@"
       enctype="multipart/form-data"
       name="CastVote">', $cr;
 
@@ -118,7 +118,7 @@ sub GenerateVoteForm {
 
     if ($writeins eq 'yes') {
 	print $cr, '<form method="post"
-	    action="http://@THISHOST@'.$civs_bin_path.'/vote@PERLEXT@"
+	    action="@PROTO@://@THISHOST@'.$civs_bin_path.'/vote@PERLEXT@"
 	    enctype="multipart/form-data"
 	    name="AddWritein">', $cr;
 	print '<p>', $tx->write_in_a_choice, $cr,

--- a/changelog.html
+++ b/changelog.html
@@ -105,6 +105,10 @@ connection with the use or performance of this software.
 Recent updates
 </h2>
 <ul>
+<li>unreleased (June 2015):</li>
+    <ul>
+      <li>Allow the use of HTTPS via new config setting PROTO.
+    </ul>
 <li>2.17 (May 2014):</li>
     <ul>
       <li>Poll descriptions can now be edited by the poll supervisor.

--- a/config/sample
+++ b/config/sample
@@ -5,6 +5,9 @@
 # changed to point to another installation.
 CIVSHOME='http://www.cs.cornell.edu/andru/civs.html'
 
+# The protocol for accessing CIVS (http or https)
+PROTO=http
+
 # The address of the web server that is hosting CIVS (may include port number)
 THISHOST='MyServer.MyUniversity.edu'
 
@@ -36,7 +39,7 @@ CGIBINDIR='/home/username/public_cgi-bin/civs'
 CIVSDATADIR='/home/username/civs'
 
 # The URL path to the CIVS CGI scripts.  This is relative to $THISHOST.
-# I.e., the scripts will be found at http://$THISHOST$CIVSBINURL.
+# I.e., the scripts will be found at $PROTO://$THISHOST$CIVSBINURL.
 CIVSBINURL='/cgi-bin/username/civs'
 
 # The URL to the homepage of the CIVS server, relative to http://$THISHOST

--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@ the use of this service.
 <script type="text/javascript">
     fetch_content('newsfeed', '@CIVSURL@/news.html',
 	function() {
-	    fetch_content('top_polls', 'http://@THISHOST@@CIVSBINURL@/get_top_polls@PERLEXT@');
+	    fetch_content('top_polls', '@PROTO@://@THISHOST@@CIVSBINURL@/get_top_polls@PERLEXT@');
 	});
 </script>
 </body>

--- a/index.html.pt
+++ b/index.html.pt
@@ -134,6 +134,6 @@ Este serviço de votação é disponibilizado para uso público e gratuito. Não
 </small></p>
 </div>
 </div>
-<script type="text/javascript">fetch_content('top_polls', 'http://@THISHOST@@CIVSBINURL@/get_top_polls@PERLEXT@')</script>
+<script type="text/javascript">fetch_content('top_polls', '@PROTO@://@THISHOST@@CIVSBINURL@/get_top_polls@PERLEXT@')</script>
 </body>
 </html>

--- a/install-civs
+++ b/install-civs
@@ -47,6 +47,7 @@ rm $CIVSDATADIR/elections/admission_control $CIVSDATADIR/lockserv
 	echo "copying $f to $dest"
 	sed  -e 's|@PERL@|'$PERL'|' \
 	     -e 's|@CGIBINDIR@|'$CGIBINDIR'|'\
+	     -e 's|@PROTO@|'$PROTO'|' \
 	     -e 's|@THISHOST@|'$THISHOST'|' \
 	     -e 's|@CIVSDATADIR@|'$CIVSDATADIR'|' \
 	     -e 's|@CIVSBINURL@|'$CIVSBINURL'|' \
@@ -87,6 +88,7 @@ rm $CIVSDATADIR/elections/admission_control $CIVSDATADIR/lockserv
 	echo " ->$target"
 	sed  -e 's|@PERL@|'$PERL'|' \
 	     -e 's|@CGIBINDIR@|'$CGIBINDIR'|'\
+	     -e 's|@PROTO@|'$PROTO'|' \
 	     -e 's|@THISHOST@|'$THISHOST'|' \
 	     -e 's|@CIVSDATADIR@|'$CIVSDATADIR'|' \
 	     -e 's|@CIVSBINURL@|'$CIVSBINURL'|' \

--- a/public_elections.html
+++ b/public_elections.html
@@ -41,27 +41,27 @@ appear on this list.</p>
 <li>
 <a href="http://www.cs.cornell.edu/w8/~andru/cgi-perl/civs/vote.pl?id=E_2f518db8cac442cf&akey=77fb34f2ed44ee86">Recommend a good book</a>
 
-<li><a href="http://@THISHOST@@CIVSBINURL@/vote@PERLEXT@?id=E_054b748ca9ace717">
+<li><a href="@PROTO@://@THISHOST@@CIVSBINURL@/vote@PERLEXT@?id=E_054b748ca9ace717">
 Hypothetical 2004 Presidential Election</a></li>
 
-<!-- <li><a href="http://@THISHOST@@CIVSBINURL@/vote@PERLEXT@?id=E_089eef32f3a319b7">
+<!-- <li><a href="@PROTO@://@THISHOST@@CIVSBINURL@/vote@PERLEXT@?id=E_089eef32f3a319b7">
 Favorite Ice Cream Flavors</a> -->
 
 <li>
 <a href="http://www.cs.cornell.edu/w8/~andru/cgi-perl/civs/vote.pl?id=E_4e62bfdb14d5f61e&akey=3f460c25aaa1f858">Favorite Movies</a>
-<a href="http://@THISHOST@@CIVSBINURL@/vote@PERLEXT@?id=E_2dd041b9e6993e78">(round 1)</a>
-<a href="http://@THISHOST@@CIVSBINURL@/results@PERLEXT@?id=E_384d07b975f0e911&akey=76f9ef9925ff6c0a">(round 2)</a>
+<a href="@PROTO@://@THISHOST@@CIVSBINURL@/vote@PERLEXT@?id=E_2dd041b9e6993e78">(round 1)</a>
+<a href="@PROTO@://@THISHOST@@CIVSBINURL@/results@PERLEXT@?id=E_384d07b975f0e911&akey=76f9ef9925ff6c0a">(round 2)</a>
 </li>
-<li><a href="http://@THISHOST@@CIVSBINURL@/vote@PERLEXT@?id=E_9c65094a4730f9bc">Ice Cream Assortment</a></li>
+<li><a href="@PROTO@://@THISHOST@@CIVSBINURL@/vote@PERLEXT@?id=E_9c65094a4730f9bc">Ice Cream Assortment</a></li>
 <li>
 <a href="http://www.cs.cornell.edu/w8/~andru/cgi-perl/civs/vote.pl?id=E_abe4aabf49a217e6&akey=931c12384fd4e886">Democratic Presidential Primary 2008</a>
 <a href="http://www.cs.cornell.edu/w8/~andru/cgi-perl/civs/results.pl?id=E_d7241556a584a0ca">(Results from round 4)</a>
-(<a href="http://@THISHOST@@CIVSBINURL@/results@PERLEXT@?id=E_6a996509644c8c88&akey=ac98e0f71403c0c7">Results from round 3</a>)
+(<a href="@PROTO@://@THISHOST@@CIVSBINURL@/results@PERLEXT@?id=E_6a996509644c8c88&akey=ac98e0f71403c0c7">Results from round 3</a>)
 </li>
 <li>
 <a href="http://www.cs.cornell.edu/w8/~andru/cgi-perl/civs/vote.pl?id=E_4396d0e428482b6d&akey=e311f4c57a690275">
 Republican Presidential Primary 2008</a>
-<a href="http://@THISHOST@@CIVSBINURL@/results@PERLEXT@?id=E_7541c7e956308389">
+<a href="@PROTO@://@THISHOST@@CIVSBINURL@/results@PERLEXT@?id=E_7541c7e956308389">
 (Results from Round 1)</a></li>
 <li><a href="@SUGGESTION_BOX@">
 CIVS Suggestion Box</a>

--- a/publicized_polls.html
+++ b/publicized_polls.html
@@ -35,6 +35,6 @@
 </table>
 <div id="top_polls" class="contents">Loading poll information...JavaScript must be enabled for this web page to work correctly.</div>
 
-<script>fetch_content('top_polls', 'http://@THISHOST@@CIVSBINURL@/get_top_polls@PERLEXT@?full=yes')</script>
+<script>fetch_content('top_polls', '@PROTO@://@THISHOST@@CIVSBINURL@/get_top_polls@PERLEXT@?full=yes')</script>
 </body>
 </html>


### PR DESCRIPTION
This introduces a new configuration parameter PROTO which defaults to "http".  Notice that it will use https to fetch jquery code to avoid the "mixed security" warning from Firefox/Chrome -- these external resources have been verified to be available over HTTPS as well.

The patch set also includes two minor bugfixes to get_top_polls.