### PR TITLE
Fix 554 Error of votes with yahoo mail.

### DIFF
--- a/cgi-bin/election.pm
+++ b/cgi-bin/election.pm
@@ -579,7 +579,7 @@ sub SendKeys {
             Send "rcpt to:<$v>"; ConsumeSMTP;
             Send "data"; ConsumeSMTP;
 	    SendHeader ('From',
-		$tx->CIVS_poll_supervisor($name).
+		$tx->CIVS_poll_supervisor($name),
 		"<$civs_supervisor>");
             SendHeader('Sender', $civs_supervisor);
             SendHeader('Reply-To', $email_addr);


### PR DESCRIPTION
Yahoo mail will reject encoded From header like this:
From: =?utf-8?B?IuWKieS/iuWujyAoQ0lWUyBwb2xsIHN1cGVydmlzb3IpIjxsb3Vpc2xp?=
 =?utf-8?B?dUBsb2NvbW90aW9uLnR3Pg==?=