### PR TITLE
Always show pending invites

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -39,6 +39,34 @@ INSTALLATION INSTRUCTIONS
      subdirectory such as extra/.
    * Add index.html.var to the DirectoryIndex option (may be in dir.conf)
 
+   For example:
+
+        DocumentRoot /srv/webroot/html
+        <Directory /srv/webroot/html>
+                Options Indexes FollowSymLinks
+                AllowOverride None
+                Require all granted
+        </Directory>
+
+        <Directory "/srv/webroot/html/civs">
+            AddHandler type-map .var
+            DirectoryIndex index.html.var
+
+            AllowOverride None
+            Options None +MultiViews
+            Require all granted
+        </Directory>
+
+        ScriptAlias /cgi-bin "/srv/webroot/cgi-bin"
+        <Directory "/srv/webroot/cgi-bin">
+            AddHandler cgi-script .cgi .pl
+            AddHandler type-map .var
+
+            AllowOverride None
+            Options None +MultiViews +ExecCGI
+            Require all granted
+        </Directory>
+
 4. Install necessary Perl modules using apt-get, cpan or cpanm (cpanminus):
 
    For basic operation:

--- a/INSTALL
+++ b/INSTALL
@@ -57,6 +57,16 @@ INSTALLATION INSTRUCTIONS
       Net::SSLeay (possibly)
       Also install openssl and libssl-dev
 
+   On a Debian-based distribution, these can be installed with:
+
+      sudo apt install \
+		libhtml-tagfilter-perl \
+		libhtml-parser-perl \
+		libhtml-tagset-perl \
+		libcgi-pm-perl \
+		libauthen-sasl-perl \
+		libnet-ssleay-perl
+
 5. Test the server installation by browsing to $CIVSURL, creating
    an election, adding yourself as a voter, opening the election,
    voting in the election, closing the election, and viewing the


### PR DESCRIPTION
If someone opts in and closes their browser window without visiting their pending invites, they have no way to find their invites again later. (The emails weren't sent because they hadn't opted in yet, but now that they're activated, they can't see the list again.) Instead, always show the list of pending invites.

I haven't tested this yet, as I'm not sure this is the way you'd want to do this in the tool, but I thought I'd try sending a patch instead of a bug report. :)