### PR TITLE
Increase TLD maximum length

### DIFF
--- a/cgi-bin/mail.pm
+++ b/cgi-bin/mail.pm
@@ -48,7 +48,7 @@ sub CheckAddr {
     (my $addr) = @_;
     $addr = &TrimAddr($addr);
 
-    return ($addr =~ m/^[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?:[A-Z]{2,8})$/i);
+    return ($addr =~ m/^[a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+(?:[A-Z]{2,18})$/i);
 }
 
 # Convert an email address into canonical form.  All whitespace is removed, the


### PR DESCRIPTION
A user with a .construction (length 13) Email pointed this out: https://github.com/NixOS/SC-election-2024/pull/6

I'm updating it to 18, because there's TLDs like https://nic.travelersinsurance/, though in theory you can have TLDs up to length 63, see https://stackoverflow.com/a/22038535.