### PR TITLE
Fix minimax comparison when margins are tied

### DIFF
--- a/cgi-bin/minimax.pm
+++ b/cgi-bin/minimax.pm
@@ -17,7 +17,7 @@ sub compare_defeats {
 # compare margins and then 'win' votes if margins are equal
         (($b->[1] - $b->[2]) <=> ($a->[1] - $a->[2]))
         ||
-        ($a->[1] <=> $b->[1])
+        ($b->[1] <=> $a->[1])
     }
 }
 


### PR DESCRIPTION
This fixes the result for the following voting profile:

    A>B>C x3
    B>C>A x2
    C>A=B x2

Defeats:

    . 3 3
    2 . 5
    4 2 .

Candidate A's worst defeat has a margin of 1 (against C). Candidate B's worst defeat has a margin of 1 (against A). Candidate C's worst defeat has a margin of 3 (against B).

A and B are tied on margin.
In candidate A's worst defeat, 4 voters ranked A below C. In candidate B's worst defeat, 3 voters ranked B below A.

This change makes B the winner instead of A.